### PR TITLE
chore(jitpack): use openjdk at jitpack

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,4 +1,2 @@
-before_install:
-  - source "$HOME/.sdkman/bin/sdkman-init.sh"
-  - sdk update
-  - sdk env install
+jdk:
+  - openjdk17


### PR DESCRIPTION
fails release build with SDKMAN

https://jitpack.io/com/github/RyuNen344/WebAuthnKt/1.0.0-alpha07/build.log

```log
Build starting...
Start: Mon May 13 16:36:33 UTC 2024 5b982186e099
Git:
1.0.0-alpha07-0-g290c5b2
commit 290c5b271300f01211c4a1e083644efb9f9ce17a
Author: github-actions[bot] 
Date:   Mon May 13 16:32:16 2024 +0000

    release: 1.0.0-alpha07 (#78)
    

Init SDKMan
Running before_install command:
source "$HOME/.sdkman/bin/sdkman-init.sh";sdk update;sdk env install
[1;36mBroadcasts discontinued. Please follow @sdkman_ on Twitter for announcements.[0m

[1;32mAdding new candidates(s): activemq ballerina bld ceylon connor coursier crash detekt doctoolchain dotty flink gcn glide grace gradleprofiler hadoop helidon http4k jarviz jikkou jmc jmeter joern jreleaser kcctl ki kobweb ktlint ktx layrry lazybones liquibase mcs mvnd mybatis neo4jmigrations pierrot pomchecker quarkus scalacli schemacrawler skeletal taxi test tomcat toolkit webtau znai [0m

[1;33mPlease open a new terminal now...[0m
Invalid command: env

Usage: sdk <command> [candidate] [version]
       sdk offline <enable|disable>

   commands:
       install   or i    <candidate> [version] [local-path]
       uninstall or rm   <candidate> <version>
       list      or ls   [candidate]
       use       or u    <candidate> <version>
       default   or d    <candidate> [version]
       current   or c    [candidate]
       upgrade   or ug   [candidate]
       version   or v
       broadcast or b
       help      or h
       offline           [enable|disable]
       selfupdate        [force]
       update
       flush             <broadcast|archives|temp>

   candidate  :  the SDK to install: groovy, scala, grails, gradle, kotlin, etc.
                 use list command for comprehensive list of candidates
                 eg: $ sdk list
   version    :  where optional, defaults to latest stable if not provided
                 eg: $ sdk install groovy
   local-path :  optional path to an existing local installation
                 eg: $ sdk install groovy 2.4.13-local /opt/groovy-2.4.13


[1;31mStop! install is not a valid candidate.[0m
Found gradle
Gradle build script
Found gradle version: 8.7.
Using gradle wrapper
Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8 -Dhttps.protocols=TLSv1.2
Downloading https://services.gradle.org/distributions/gradle-8.7-bin.zip
.10%.20%.30%.40%.50%.60%.70%.80%.90%.100%

------------------------------------------------------------
Gradle 8.7
------------------------------------------------------------

Build time:   2024-03-22 15:52:46 UTC
Revision:     650af14d7653aa949fce5e886e685efc9cf97c10

Kotlin:       1.9.22
Groovy:       3.0.17
Ant:          Apache Ant(TM) version 1.10.13 compiled on January 4 2023
JVM:          1.8.0_252 (Private Build 25.252-b09)
OS:           Linux 4.10.0-28-generic amd64

0m3.304s
Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8 -Dhttps.protocols=TLSv1.2
openjdk version "1.8.0_252"
OpenJDK Runtime Environment (build 1.8.0_252-8u252-b09-1~16.04-b09)
OpenJDK 64-Bit Server VM (build 25.252-b09, mixed mode)
Getting tasks: ./gradlew tasks --all
Tasks: 

 ⚠️   WARNING:
 Gradle 'publishToMavenLocal' task not found. Please add the 'maven-publish' or 'maven' plugin.
 See the documentation and examples: https://docs.jitpack.io

Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8 -Dhttps.protocols=TLSv1.2

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'WebAuthnKt'.
> Could not resolve all artifacts for configuration ':classpath'.
   > Could not resolve com.android.tools.build:gradle:8.4.0.
     Required by:
         project : > com.android.library:com.android.library.gradle.plugin:8.4.0
      > No matching variant of com.android.tools.build:gradle:8.4.0 was found. The consumer was configured to find a library for use during runtime, compatible with Java 8, packaged as a jar, and its dependencies declared externally, as well as attribute 'org.gradle.plugin.api-version' with value '8.7' but:
          - Variant 'apiElements' declares a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component for use during compile-time, compatible with Java 11 and the consumer needed a component for use during runtime, compatible with Java 8
              - Other compatible attribute:
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.7')
          - Variant 'javadocElements' declares a component for use during runtime, and its dependencies declared externally:
              - Incompatible because this component declares documentation and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about its elements (required them packaged as a jar)
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.7')
          - Variant 'runtimeElements' declares a library for use during runtime, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component, compatible with Java 11 and the consumer needed a component, compatible with Java 8
              - Other compatible attribute:
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.7')
          - Variant 'sourcesElements' declares a component for use during runtime, and its dependencies declared externally:
              - Incompatible because this component declares documentation and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about its elements (required them packaged as a jar)
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.7')

* Try:
> Review the variant matching algorithm at https://docs.gradle.org/8.7/userguide/variant_attributes.html#sec:abm_algorithm.
> No matching variant errors are explained in more detail at https://docs.gradle.org/8.7/userguide/variant_model.html#sub:variant-no-match.
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Get more help at https://help.gradle.org.

BUILD FAILED in 770ms
Running: ./gradlew -Pgroup=com.github.RyuNen344 -Pversion=1.0.0-alpha07 publishToMavenLocal
Calculating task graph as no cached configuration is available for tasks: publishToMavenLocal
Type-safe project accessors is an incubating feature.

The build scan was not published due to a configuration problem.

The buildScan extension 'termsOfUseAgree' value must be exactly the string 'yes' (without quotes).
The value given was 'no'.

For more information, please see https://gradle.com/help/gradle-plugin-terms-of-use.

Alternatively, if you are using Develocity, specify the server location.
For more information, please see https://gradle.com/help/gradle-plugin-config.

Configuration cache entry stored.
Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8 -Dhttps.protocols=TLSv1.2

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'WebAuthnKt'.
> Could not resolve all artifacts for configuration ':classpath'.
   > Could not resolve com.android.tools.build:gradle:8.4.0.
     Required by:
         project : > com.android.library:com.android.library.gradle.plugin:8.4.0
      > No matching variant of com.android.tools.build:gradle:8.4.0 was found. The consumer was configured to find a library for use during runtime, compatible with Java 8, packaged as a jar, and its dependencies declared externally, as well as attribute 'org.gradle.plugin.api-version' with value '8.7' but:
          - Variant 'apiElements' declares a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component for use during compile-time, compatible with Java 11 and the consumer needed a component for use during runtime, compatible with Java 8
              - Other compatible attribute:
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.7')
          - Variant 'javadocElements' declares a component for use during runtime, and its dependencies declared externally:
              - Incompatible because this component declares documentation and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about its elements (required them packaged as a jar)
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.7')
          - Variant 'runtimeElements' declares a library for use during runtime, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component, compatible with Java 11 and the consumer needed a component, compatible with Java 8
              - Other compatible attribute:
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.7')
          - Variant 'sourcesElements' declares a component for use during runtime, and its dependencies declared externally:
              - Incompatible because this component declares documentation and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about its elements (required them packaged as a jar)
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.7')

* Try:
> Review the variant matching algorithm at https://docs.gradle.org/8.7/userguide/variant_attributes.html#sec:abm_algorithm.
> No matching variant errors are explained in more detail at https://docs.gradle.org/8.7/userguide/variant_model.html#sub:variant-no-match.
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Get more help at https://help.gradle.org.

BUILD FAILED in 607ms
Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8 -Dhttps.protocols=TLSv1.2

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'WebAuthnKt'.
> Could not resolve all artifacts for configuration ':classpath'.
   > Could not resolve com.android.tools.build:gradle:8.4.0.
     Required by:
         project : > com.android.library:com.android.library.gradle.plugin:8.4.0
      > No matching variant of com.android.tools.build:gradle:8.4.0 was found. The consumer was configured to find a library for use during runtime, compatible with Java 8, packaged as a jar, and its dependencies declared externally, as well as attribute 'org.gradle.plugin.api-version' with value '8.7' but:
          - Variant 'apiElements' declares a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component for use during compile-time, compatible with Java 11 and the consumer needed a component for use during runtime, compatible with Java 8
              - Other compatible attribute:
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.7')
          - Variant 'javadocElements' declares a component for use during runtime, and its dependencies declared externally:
              - Incompatible because this component declares documentation and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about its elements (required them packaged as a jar)
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.7')
          - Variant 'runtimeElements' declares a library for use during runtime, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component, compatible with Java 11 and the consumer needed a component, compatible with Java 8
              - Other compatible attribute:
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.7')
          - Variant 'sourcesElements' declares a component for use during runtime, and its dependencies declared externally:
              - Incompatible because this component declares documentation and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about its elements (required them packaged as a jar)
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about org.gradle.plugin.api-version (required '8.7')

* Try:
> Review the variant matching algorithm at https://docs.gradle.org/8.7/userguide/variant_attributes.html#sec:abm_algorithm.
> No matching variant errors are explained in more detail at https://docs.gradle.org/8.7/userguide/variant_model.html#sub:variant-no-match.
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Get more help at https://help.gradle.org.

BUILD FAILED in 642ms
Build tool exit code: 0
Looking for artifacts...
Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8 -Dhttps.protocols=TLSv1.2
Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8 -Dhttps.protocols=TLSv1.2
Looking for pom.xml in build directory and ~/.m2
2024-05-13T16:36:57.277550906Z
Exit code: 0

⚠️ ERROR: No build artifacts found

```
